### PR TITLE
Add shebang and make convert_single_session.py executable

### DIFF
--- a/src/convert_single_session.py
+++ b/src/convert_single_session.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # import manimoh_nwb_converters as mnc
 
 # raw_session_dir = '/mnt/datasets/incoming/mvdm/OdorSequence/sourcedata/raw/M541/M541-2024-08-31_g0'


### PR DESCRIPTION
it would avoid you need to run it with `python ` explicitly, just do `./convert_single_session.py` and would let me make it an entry point for the container (although may be we do not actually want that since there would be more scripts I assume)